### PR TITLE
fix: 정적 사이트 생성을 위한 next export 추가

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,36 +1,27 @@
-# Sample workflow for building and deploying a Next.js site to GitHub Pages
-#
-# To get started with Next.js see: https://nextjs.org/docs/getting-started
-#
 name: Deploy Next.js site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -48,33 +39,38 @@ jobs:
             echo "Unable to determine package manager"
             exit 1
           fi
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Restore cache
         uses: actions/cache@v4
         with:
           path: |
             .next/cache
-          # Generate a new cache whenever packages or source files change.
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+
       - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        run: |
+          ${{ steps.detect-package-manager.outputs.runner }} next build
+          ${{ steps.detect-package-manager.outputs.runner }} next export
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,16 @@
 const { withContentlayer } = require("next-contentlayer");
 
+const prefix =
+    process.env.NODE_ENV === "production"
+        ? "https://meetyourbook.github.io/"
+        : "";
+
 const nextConfig = {
     reactStrictMode: true,
     swcMinify: true,
+    output: "export",
+    basePath: prefix,
+    assetPrefix: prefix,
 };
 
 module.exports = withContentlayer(nextConfig);

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import Comment from "@/src/components/Comments/Comments";
 
+// MDX 컴포넌트 커스텀 스타일 정의
 const mdxComponents: MDXComponents = {
     a: ({ href, children }) => <Link href={href as string}>{children}</Link>,
     ul: (props) => <ul className="m-0 p-0 list-none" {...props} />,
@@ -16,11 +17,13 @@ const mdxComponents: MDXComponents = {
     h4: (props) => <h4 className="dark:text-white" {...props} />,
 };
 
+// 포스트 페이지 컴포넌트
 export default function Page({ params }: { params: { slug: string } }) {
-    const post = allPosts.find(
-        (post) => post._raw.flattenedPath === params.slug
-    );
-    if (!post) notFound();
+    const post = allPosts.find((post) => post._raw.flattenedPath === params.slug);
+
+    if (!post) {
+        notFound();
+    }
 
     const MDXContent = useMDXComponent(post.body.code);
 
@@ -31,9 +34,7 @@ export default function Page({ params }: { params: { slug: string } }) {
                     dateTime={post.date}
                     className="text-sm text-gray-600 dark:text-gray-300"
                 >
-                    {new Intl.DateTimeFormat("en-US").format(
-                        new Date(post.date)
-                    )}
+                    {new Intl.DateTimeFormat("en-US").format(new Date(post.date))}
                 </time>
                 <h1 className="text-3xl font-bold dark:text-white mt-3">
                     {post.title}
@@ -46,4 +47,10 @@ export default function Page({ params }: { params: { slug: string } }) {
             </div>
         </article>
     );
+}
+
+export async function generateStaticParams() {
+    return allPosts.map((post) => ({
+        slug: post._raw.flattenedPath,
+    }));
 }


### PR DESCRIPTION
- GitHub Pages 배포를 위해 next build 후 next export 명령 추가
- 정적 HTML 파일이 ./out 디렉토리에 저장되도록 설정
- Next.js 사이트의 정적 배포를 위한 워크플로우 업데이트